### PR TITLE
Fix bug: Non chat commands are not recognized

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -729,7 +729,7 @@ const actionCodecs = {
 const TriageAction = Struct([
   ['actionType', t.uint8],
   ...Object.keys(actionCodecs).map((id) =>
-    t.if(s => s.actionType === id, actionCodecs[id])
+    t.if(s => s.actionType === Number(id), actionCodecs[id])
   )
 ])
 


### PR DESCRIPTION
On TriageAction definition, Object.keys() returns an array of
strings, but they were compared to s.actionType, which is a number.
That caused that no action were ever matched.